### PR TITLE
Make keywords be as covariant as possible

### DIFF
--- a/Dsl/src/main/scala/com/thoughtworks/dsl/Dsl.scala
+++ b/Dsl/src/main/scala/com/thoughtworks/dsl/Dsl.scala
@@ -513,7 +513,7 @@ object Dsl extends LowPriorityDsl0 {
       */
     opaque type Opaque = Any
     object Opaque {
-      opaque type Of[Self] <: Self & Opaque = Self
+      opaque type Of[+Self] <: Self & Opaque = Self
       object Of {
         def apply[Self]: Self =:= Of[Self] = summon
       }

--- a/domains-scalaz/src/main/scala/com/thoughtworks/dsl/domains/scalaz.scala
+++ b/domains-scalaz/src/main/scala/com/thoughtworks/dsl/domains/scalaz.scala
@@ -215,19 +215,19 @@ object scalaz {
 
     }
 
-  implicit def scalazMonadicDsl[F[_], A, B](implicit bind: Bind[F]): Dsl[Monadic[F, A], F[B], A] =
-    new Dsl[Monadic[F, A], F[B], A] {
-      def cpsApply(keyword: Monadic[F, A], handler: A => F[B]): F[B] = {
+  implicit def scalazMonadicDsl[F[_], A, B](implicit bind: Bind[F]): Dsl[Monadic[F[A]], F[B], A] =
+    new Dsl[Monadic[F[A]], F[B], A] {
+      def cpsApply(keyword: Monadic[F[A]], handler: A => F[B]): F[B] = {
         bind.bind(Monadic.apply.flip(keyword))(handler)
       }
     }
 
-  abstract class ScalazTransformerDsl[F[_], G[_], A, B] extends Dsl[Monadic[F, A], G[B], A] {
+  abstract class ScalazTransformerDsl[F[_], G[_], A, B] extends Dsl[Monadic[F[A]], G[B], A] {
     def monad: Monad[G]
 
     def lift(fa: F[A]): G[A]
 
-    final def cpsApply(keyword: Monadic[F, A], handler: A => G[B]): G[B] = {
+    final def cpsApply(keyword: Monadic[F[A]], handler: A => G[B]): G[B] = {
       monad.bind(lift(Monadic.apply.flip(keyword)))(handler)
     }
 

--- a/keywords-AsynchronousIo/src/main/scala/com/thoughtworks/dsl/keywords/AsynchronousIo.scala
+++ b/keywords-AsynchronousIo/src/main/scala/com/thoughtworks/dsl/keywords/AsynchronousIo.scala
@@ -7,6 +7,7 @@ import java.nio.channels._
 import com.thoughtworks.dsl.Dsl.{!!, IsKeyword}
 
 import scala.util.control.NonFatal
+import scala.annotation.unchecked.uncheckedVariance
 
 /** The base keyword to perform asynchronous IO in [[domains.task.Task]]s.
   *
@@ -76,10 +77,15 @@ import scala.util.control.NonFatal
   *          })
   *          }}}
   */
-trait AsynchronousIo[Value] extends Any with Dsl.Keyword.Trait {
+trait AsynchronousIo[+Value] extends Any with Dsl.Keyword.Trait {
 
   /** Starts the asynchronous operations */
-  protected def start[Attachment](attachment: Attachment, handler: CompletionHandler[Value, _ >: Attachment]): Unit
+  protected def start[Attachment](
+      attachment: Attachment,
+      // CompletionHandler is essentially covariant even though Java does not
+      // support covariance
+      handler: CompletionHandler[Value @uncheckedVariance, _ >: Attachment]
+  ): Unit
 }
 
 object AsynchronousIo {

--- a/keywords-Await/src/main/scala/com/thoughtworks/dsl/keywords/Await.scala
+++ b/keywords-Await/src/main/scala/com/thoughtworks/dsl/keywords/Await.scala
@@ -111,7 +111,7 @@ import scala.language.implicitConversions
   * @author
   *   杨博 (Yang Bo)
   */
-opaque type Await[AwaitableValue] <: Dsl.Keyword.Opaque =
+opaque type Await[+AwaitableValue] <: Dsl.Keyword.Opaque =
   Dsl.Keyword.Opaque.Of[AwaitableValue]
 object Await extends AwaitJS {
   @inline def apply[AwaitableValue]: AwaitableValue =:= Await[AwaitableValue] =

--- a/keywords-Await/src/test/scala/com/thoughtworks/dsl/keywords/AwaitTest.scala
+++ b/keywords-Await/src/test/scala/com/thoughtworks/dsl/keywords/AwaitTest.scala
@@ -100,10 +100,8 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
         <:<
           FlatMap[
             Await[Future[Int]],
-            Int,
             FlatMap[
               Each[Int],
-              Int,
               Pure[collection.View[Int]]
             ]
           ]
@@ -146,12 +144,12 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     val reified = reify {
       !Await(Future(!Await(Future(1L))))
     }
-    summon[reified.type <:< Typed[FlatMap[Await[Future[Long]], Long, Await[
+    summon[reified.type <:< Typed[FlatMap[Await[Future[Long]], Await[
       Future[Long]
     ]], Long]]
     summon[
       Run[
-        FlatMap[Await[Future[Long]], Long, Await[Future[Long]]],
+        FlatMap[Await[Future[Long]], Await[Future[Long]]],
         Future[Long],
         Long
       ]
@@ -167,12 +165,12 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
       !Await(Future(i))
     }
     summon[reified.type <:< Typed[
-      FlatMap[Await[Future[String]], String, Await[Future[String]]],
+      FlatMap[Await[Future[String]], Await[Future[String]]],
       String
     ]]
     summon[
       Run[
-        FlatMap[Await[Future[String]], String, Await[Future[String]]],
+        FlatMap[Await[Future[String]], Await[Future[String]]],
         Future[String],
         String
       ]
@@ -195,12 +193,12 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
       }
       !Await(Future(A.j))
     }
-    summon[reified.type <:< Typed[FlatMap[Await[Future[Long]], Long, Await[
+    summon[reified.type <:< Typed[FlatMap[Await[Future[Long]], Await[
       Future[Long]
     ]], Long]]
     summon[
       Run[
-        FlatMap[Await[Future[Long]], Long, Await[Future[Long]]],
+        FlatMap[Await[Future[Long]], Await[Future[Long]]],
         Future[Long],
         Long
       ]
@@ -219,8 +217,7 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
       reified.type <:<
         Typed[FlatMap[
           Await[Future[Unit]],
-          Unit,
-          FlatMap[Return[Unit], Nothing, Pure[Unit]]
+          FlatMap[Return[Unit], Pure[Unit]]
         ], Unit]
     ]
 
@@ -302,10 +299,9 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
         reified.type <:<
           Typed[FlatMap[
             Pure[Int],
-            Int,
             Match.WithIndex[(0), Pure[LazyList[Nothing]]]
               +:
-                Match.WithIndex[(1), FlatMap[Yield[Int], Unit, Pure[
+                Match.WithIndex[(1), FlatMap[Yield[Int], Pure[
                   LazyList[Int]
                 ]]]
                 +: Nothing
@@ -336,10 +332,9 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
             Await[Future[String]]
           ], Match.WithIndex[0, FlatMap[
             Await[Future[Int]],
-            Int,
             FlatMap[Await[
               Future[Int]
-            ], Int, Pure[String]]
+            ], Pure[String]]
           ]]
             +: Nothing, Suspend[Pure[Unit]]],
           String
@@ -388,17 +383,15 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
         Typed[keywords.TryCatch[Suspend[
           FlatMap[
             Await[Future[Int]],
-            Int,
             FlatMap[Await[
               Future[Int]
-            ], Int, Pure[String]]
+            ], Pure[String]]
           ]
         ], Match.WithIndex[0, FlatMap[
           Await[Future[Int]],
-          Int,
           FlatMap[Await[
             Future[Int]
-          ], Int, Pure[String]]
+          ], Pure[String]]
         ]]
           +: Nothing], String]
     ]
@@ -424,9 +417,9 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
           Suspend[
             FlatMap[Await[
               Future[Int]
-            ], Int, Pure[Unit]]
+            ], Pure[Unit]]
           ]
-        ], Unit, Pure[Long]], Long]
+        ], Pure[Long]], Long]
     ]
     *[Future] {
       !Await(reified.to[Future]) should be(3L)
@@ -444,16 +437,15 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     }
     summon[
       reified.type <:<
-        Typed[FlatMap[
-          Await[Future[A.type]],
-          A.type,
-          FlatMap[
-            Await[Future[String]],
-            String,
-            Pure[String]
+        com.thoughtworks.dsl.keywords.Typed[
+          com.thoughtworks.dsl.keywords.FlatMap[
+            com.thoughtworks.dsl.keywords.Await[scala.concurrent.Future[A.type]]
+          , 
+            com.thoughtworks.dsl.keywords.FlatMap[
+              com.thoughtworks.dsl.keywords.Await[scala.concurrent.Future[String]]
+            , com.thoughtworks.dsl.keywords.Pure[String]]
           ]
-        ], String]
-    ]
+        , String]    ]
     reified.to[Future].map(_ should be("X"))
   }
 
@@ -465,14 +457,18 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     }
     summon[
       reified.type <:<
-        Typed[FlatMap[
-          Await[Future[CharSequence]],
-          CharSequence,
-          FlatMap[Await[
-            Future[CharSequence]
-          ], CharSequence, Pure[Object]]
-        ], Object]
-    ]
+        com.thoughtworks.dsl.keywords.Typed[
+          com.thoughtworks.dsl.keywords.FlatMap[
+            com.thoughtworks.dsl.keywords.Await[concurrent.Future[CharSequence]]
+          , 
+            com.thoughtworks.dsl.keywords.FlatMap[
+              com.thoughtworks.dsl.keywords.Await[
+                scala.concurrent.Future[CharSequence]
+              ]
+            , com.thoughtworks.dsl.keywords.Pure[Object]]
+          ],
+        AnyRef
+    ]]
     reified.to[Future].map(_ should be("x"))
   }
 
@@ -505,12 +501,15 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     }
     summon[
       reified.type <:<
-        Typed[FlatMap[
-          Await[Future[Int => Int]],
-          Int => Int,
-          Await[Future[Any => Boolean]]
-        ], Any => Boolean]
-    ]
+        com.thoughtworks.dsl.keywords.Typed[
+          com.thoughtworks.dsl.keywords.FlatMap[
+            com.thoughtworks.dsl.keywords.Await[scala.concurrent.Future[Int => Int]]
+          , 
+            com.thoughtworks.dsl.keywords.Await[
+              scala.concurrent.Future[Any => Boolean]
+            ]
+          ]
+        , Any => Boolean]    ]
     reified.to[Future].map {
       _ should be(a[Function1[_, _]])
     }
@@ -523,12 +522,17 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     }
     summon[
       reified.type <:<
-        Typed[FlatMap[
-          FlatMap[Await[Future[Int => Int]], Int => Int, Pure[Any => Boolean]],
-          Any => Boolean,
-          Await[Future[Any => Boolean]]
-        ], Any => Boolean]
-    ]
+        com.thoughtworks.dsl.keywords.Typed[
+          com.thoughtworks.dsl.keywords.FlatMap[
+            com.thoughtworks.dsl.keywords.FlatMap[
+              com.thoughtworks.dsl.keywords.Await[scala.concurrent.Future[Int => Int]]
+            , com.thoughtworks.dsl.keywords.Pure[Any => Boolean]]
+          , 
+            com.thoughtworks.dsl.keywords.Await[
+              scala.concurrent.Future[Any => Boolean]
+            ]
+          ]
+        , Any => Boolean]    ]
     reified.to[Future].map {
       _ should be(a[Function1[_, _]])
     }
@@ -541,11 +545,18 @@ class AwaitTest extends AsyncFreeSpec with Matchers with Inside {
     }
     summon[
       reified.type <:<
-        Typed[FlatMap[
-          FlatMap[Await[Future[Int => Int]], Int => Int, Pure[Any => Boolean]],
-          Any => Boolean,
-          Await[Future[Any => Boolean]]
-        ], Any => Boolean]
+         com.thoughtworks.dsl.keywords.Typed[
+            com.thoughtworks.dsl.keywords.FlatMap[
+              com.thoughtworks.dsl.keywords.FlatMap[
+                com.thoughtworks.dsl.keywords.Await[scala.concurrent.Future[Int => Int]]
+              , com.thoughtworks.dsl.keywords.Pure[Any => Boolean]]
+            , 
+              com.thoughtworks.dsl.keywords.Await[
+                scala.concurrent.Future[Any => Boolean]
+              ]
+            ]
+          , Any => Boolean]
+        
     ]
     reified.to[Future].map {
       _ should be(a[Function1[_, _]])

--- a/keywords-Each/src/main/scala/com/thoughtworks/dsl/keywords/Each.scala
+++ b/keywords-Each/src/main/scala/com/thoughtworks/dsl/keywords/Each.scala
@@ -101,14 +101,13 @@ object Each {
         Nested,
       ], FlatMap[
         UpstreamKeyword,
-        collection.View[UpstreamElement],
         FlatMap[Each[
           UpstreamElement
-        ], UpstreamElement, NestedKeyword]
+        ], NestedKeyword]
       ]] = { case Dsl.For.Do.FlatForeach(upstream, flatAction) =>
         FlatMap(
           upstreamToKeyword(upstream),
-          { upstreamCollection =>
+          { (upstreamCollection: Iterable[UpstreamElement]) =>
             FlatMap(
               Each(upstreamCollection),
               flatAction.andThen(mappedToKeyword)
@@ -137,14 +136,13 @@ object Each {
         Element
       ], FlatMap[
         UpstreamKeyword,
-        collection.View[UpstreamElement],
         FlatMap[Each[
           UpstreamElement
-        ], UpstreamElement, MappedKeyword]
+        ], MappedKeyword]
       ]] = { case Dsl.For.Yield.FlatMap(upstream, flatMapper) =>
         FlatMap(
           upstreamToKeyword(upstream),
-          { upstreamCollection =>
+          { (upstreamCollection: collection.View[UpstreamElement]) =>
             FlatMap(
               Each(upstreamCollection),
               flatMapper.andThen(mappedToKeyword)
@@ -167,7 +165,6 @@ object Each {
         UpstreamElement,
       ], FlatMap[
         UpstreamKeyword,
-        collection.View[UpstreamElement],
         Pure[Unit]
       ]] = { case Dsl.For.Do.Foreach(upstream, action) =>
         FlatMap(
@@ -196,7 +193,6 @@ object Each {
         Element
       ], FlatMap[
         UpstreamKeyword,
-        collection.View[UpstreamElement],
         Pure[collection.View[Element]]
       ]] = { case Dsl.For.Yield.Map(upstream, mapper) =>
         FlatMap(
@@ -223,7 +219,6 @@ object Each {
         Element
       ], FlatMap[
         UpstreamKeyword,
-        collection.View[Element],
         Pure[collection.View[Element]]
       ]] = { case Dsl.For.Yield.WithFilter(upstream, filter) =>
         FlatMap(
@@ -245,7 +240,7 @@ object Each {
       ): ToKeyword[Dsl.For.Yield.WithFilter[
         Upstream,
         Element
-      ], FlatMap[Upstream, Element, Pure[collection.View[Element]]]] = {
+      ], FlatMap[Upstream, Pure[collection.View[Element]]]] = {
         case Dsl.For.Yield.WithFilter(upstream, filter) =>
           FlatMap(
             upstream,
@@ -269,14 +264,12 @@ object Each {
         UpstreamElement,
       ], FlatMap[
         Upstream,
-        UpstreamElement,
         Pure[Unit]
       ]] = Pure.apply.liftCo[[X] =>> ToKeyword[Dsl.For.Do.Foreach[
         Upstream,
         UpstreamElement,
       ], FlatMap[
         Upstream,
-        UpstreamElement,
         X
       ]]] { case Dsl.For.Do.Foreach(upstream, action) =>
         FlatMap(
@@ -297,12 +290,11 @@ object Each {
         Element
       ], FlatMap[
         Upstream,
-        UpstreamElement,
         Pure[collection.View[Element]]
       ]] = { case Dsl.For.Yield.Map(upstream, mapper) =>
         FlatMap(
           upstream,
-          element => Pure(collection.View.Single(mapper(element)))
+          (upstreamElement: UpstreamElement) => Pure(collection.View.Single(mapper(upstreamElement)))
         )
       }
 
@@ -320,7 +312,6 @@ object Each {
         Nested,
       ], FlatMap[
         Upstream,
-        UpstreamElement,
         NestedKeyword
       ]] = { case Dsl.For.Do.FlatForeach(upstream, flatAction) =>
         FlatMap(upstream, flatAction.andThen(mappedToKeyword))
@@ -342,7 +333,6 @@ object Each {
         Element
       ], FlatMap[
         Upstream,
-        UpstreamElement,
         MappedKeyword
       ]] = { case Dsl.For.Yield.FlatMap(upstream, flatMapper) =>
         FlatMap(upstream, flatMapper.andThen(mappedToKeyword))
@@ -424,12 +414,12 @@ object Each {
       factory: Factory[MappedElement, MappedValue],
       blockDsl: Dsl.PolyCont[MappedKeyword, Domain, MappedValue]
   ): Dsl.PolyCont[
-    FlatMap[Each[Element], Element, MappedKeyword],
+    FlatMap[Each[Element], MappedKeyword],
     Domain,
     MappedValue
   ] = {
     case (
-          FlatMap(sourceCollection, flatMapper),
+          FlatMap(sourceCollection, flatMapper: (Element @unchecked => MappedKeyword)),
           handler
         ) =>
       @inline def loop(
@@ -468,12 +458,12 @@ object Each {
   ](using
       blockDsl: Dsl.PolyCont[MappedKeyword, Domain, Unit]
   ): Dsl.PolyCont[
-    FlatMap[Each[Element], Element, MappedKeyword],
+    FlatMap[Each[Element], MappedKeyword],
     Domain,
     Unit
   ] = {
     case (
-          FlatMap(sourceCollection, flatMapper),
+          FlatMap(sourceCollection, flatMapper: (Element @unchecked => MappedKeyword)),
           handler
         ) =>
       @inline def loop(

--- a/keywords-Each/src/main/scala/com/thoughtworks/dsl/keywords/Each.scala
+++ b/keywords-Each/src/main/scala/com/thoughtworks/dsl/keywords/Each.scala
@@ -25,13 +25,13 @@ import scala.collection.mutable.Builder
   *   [[Dsl.For]] if you want to use traditional `for` comprehension instead of
   *   !-notation.
   */
-opaque type Each[Element] <: Dsl.Keyword.Opaque =
+opaque type Each[+Element] <: Dsl.Keyword.Opaque =
   Dsl.Keyword.Opaque.Of[Iterable[Element]]
 object Each {
   def apply[Element]: Iterable[Element] =:= Each[Element] =
     Dsl.Keyword.Opaque.Of.apply
 
-  final case class To[ForYield <: Dsl.For.Yield[Element], Element, Collection](
+  final case class To[+ForYield <: Dsl.For.Yield[Element], Element, +Collection](
       factory: Factory[Element, Collection]
   )(val forYield: ForYield)
       extends Dsl.Keyword.Trait
@@ -59,7 +59,7 @@ object Each {
     }
   }
 
-  opaque type ToView[Comprehension] <: Dsl.Keyword.Opaque =
+  opaque type ToView[+Comprehension] <: Dsl.Keyword.Opaque =
     Dsl.Keyword.Opaque.Of[Comprehension]
 
   object ToView {

--- a/keywords-FlatMap/src/main/scala/com/thoughtworks/dsl/keywords/FlatMap.scala
+++ b/keywords-FlatMap/src/main/scala/com/thoughtworks/dsl/keywords/FlatMap.scala
@@ -5,36 +5,38 @@ import com.thoughtworks.dsl.Dsl
 import Dsl.IsKeyword
 import scala.util.NotGiven
 
-final case class FlatMap[+Upstream, UpstreamValue, +Mapped](
+final case class FlatMap[+Upstream, +Mapped](
     upstream: Upstream,
-    flatMapper: UpstreamValue => Mapped
+    flatMapper: _ => Mapped
 ) extends Dsl.Keyword.Trait
 
 object FlatMap {
   given [Upstream, UpstreamValue, Mapped, MappedValue](using
       IsKeyword[Mapped, MappedValue]
-  ): IsKeyword[FlatMap[Upstream, UpstreamValue, Mapped], MappedValue] with {}
+  ): IsKeyword[FlatMap[Upstream, Mapped], MappedValue] with {}
 
   given [
       Upstream,
-      RealUpstreamValue,
       UpstreamValue,
       Mapped,
       MappedValue,
       Domain
   ](using
-      upstreamDsl: Dsl.PolyCont[Upstream, Domain, RealUpstreamValue],
+      upstreamDsl: Dsl.PolyCont[Upstream, Domain, UpstreamValue],
       nestedDsl: Dsl.PolyCont[Mapped, Domain, MappedValue]
-  ): Dsl.PolyCont[FlatMap[Upstream, UpstreamValue, Mapped], Domain, MappedValue] with {
+  ): Dsl.PolyCont[FlatMap[Upstream, Mapped], Domain, MappedValue] with {
     def cpsApply(
-        keyword: FlatMap[Upstream, UpstreamValue, Mapped],
+        keyword: FlatMap[Upstream, Mapped],
         handler: MappedValue => Domain
     ): Domain = {
       val FlatMap(upstream, flatMapper) = keyword
       upstreamDsl.cpsApply(
         upstream,
         { upstreamValue =>
-          nestedDsl.cpsApply(flatMapper(upstreamValue.asInstanceOf[UpstreamValue]), handler)
+          // The typer might erase the type of of parameter of the function
+          // when the parameter is a reference to a local value, therefore,
+          // we are unable to call `flatMapper` without a cast.
+          nestedDsl.cpsApply(flatMapper.asInstanceOf[UpstreamValue => Mapped](upstreamValue), handler)
         }
       )
     }

--- a/keywords-FlatMap/src/main/scala/com/thoughtworks/dsl/keywords/FlatMap.scala
+++ b/keywords-FlatMap/src/main/scala/com/thoughtworks/dsl/keywords/FlatMap.scala
@@ -5,7 +5,7 @@ import com.thoughtworks.dsl.Dsl
 import Dsl.IsKeyword
 import scala.util.NotGiven
 
-final case class FlatMap[Upstream, UpstreamValue, Mapped](
+final case class FlatMap[+Upstream, UpstreamValue, +Mapped](
     upstream: Upstream,
     flatMapper: UpstreamValue => Mapped
 ) extends Dsl.Keyword.Trait
@@ -17,12 +17,13 @@ object FlatMap {
 
   given [
       Upstream,
+      RealUpstreamValue,
       UpstreamValue,
       Mapped,
       MappedValue,
       Domain
   ](using
-      upstreamDsl: Dsl.PolyCont[Upstream, Domain, UpstreamValue],
+      upstreamDsl: Dsl.PolyCont[Upstream, Domain, RealUpstreamValue],
       nestedDsl: Dsl.PolyCont[Mapped, Domain, MappedValue]
   ): Dsl.PolyCont[FlatMap[Upstream, UpstreamValue, Mapped], Domain, MappedValue] with {
     def cpsApply(
@@ -33,7 +34,7 @@ object FlatMap {
       upstreamDsl.cpsApply(
         upstream,
         { upstreamValue =>
-          nestedDsl.cpsApply(flatMapper(upstreamValue), handler)
+          nestedDsl.cpsApply(flatMapper(upstreamValue.asInstanceOf[UpstreamValue]), handler)
         }
       )
     }

--- a/keywords-If/src/main/scala/com/thoughtworks/dsl/keywords/If.scala
+++ b/keywords-If/src/main/scala/com/thoughtworks/dsl/keywords/If.scala
@@ -3,7 +3,7 @@ package keywords
 import Dsl.IsKeyword
 import Dsl.cpsApply
 
-final case class If[ConditionKeyword, ThenKeyword, ElseKeyword](
+final case class If[+ConditionKeyword, +ThenKeyword, +ElseKeyword](
   cond: ConditionKeyword,
   thenp: ThenKeyword,
   elsep: ElseKeyword) extends Dsl.Keyword.Trait

--- a/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
+++ b/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
@@ -9,45 +9,66 @@ object Match {
 
   opaque type +:[+A, +B] = A | B
 
-  given [
-      Index <: Int,
-      Keyword,
-      Domain,
-      LastValue
-  ](using
-      dsl: Dsl.PolyCont[Keyword, Domain, LastValue],
-      valueOfIndex: ValueOf[Index]
-  ): Dsl.PolyCont[WithIndex[Index, Keyword] +: Nothing, Domain, LastValue] with {
-    def cpsApply(keywordWithIndex: WithIndex[Index, Keyword] +: Nothing, handler: LastValue => Domain): Domain = {
-      keywordWithIndex match {
-        case WithIndex(valueOfIndex.value, keyword) =>
-          dsl.cpsApply(keyword, handler)
-        case _ =>
-          throw new IllegalArgumentException("Invalid index")
+  object WithIndex:
+    
+    given [
+        Index <: Int,
+        Keyword,
+        Domain,
+        LastValue
+    ](using
+        dsl: Dsl.IsKeyword[Keyword, LastValue],
+        valueOfIndex: ValueOf[Index]
+    ): Dsl.IsKeyword[WithIndex[Index, Keyword] +: Nothing, LastValue] with {} 
+    given [
+        Index <: Int,
+        Keyword,
+        Domain,
+        LastValue
+    ](using
+        dsl: Dsl.PolyCont[Keyword, Domain, LastValue],
+        valueOfIndex: ValueOf[Index]
+    ): Dsl.PolyCont[WithIndex[Index, Keyword] +: Nothing, Domain, LastValue] with {
+      def cpsApply(keywordWithIndex: WithIndex[Index, Keyword] +: Nothing, handler: LastValue => Domain): Domain = {
+        keywordWithIndex match {
+          case WithIndex(valueOfIndex.value, keyword) =>
+            dsl.cpsApply(keyword, handler)
+          case _ =>
+            throw new IllegalArgumentException("Invalid index")
+        }
       }
     }
-  }
 
-  given [
-      Index <: Int,
-      LeftKeyword,
-      RestKeyword,
-      Domain,
-      Value
-  ](using
-      leftDsl: Dsl.PolyCont[LeftKeyword, Domain, Value],
-      valueOfIndex: ValueOf[Index],
-      restDsl: Dsl.PolyCont[RestKeyword, Domain, Value]
-  ): Dsl.PolyCont[WithIndex[Index, LeftKeyword] +: RestKeyword, Domain, Value] with {
-    def cpsApply(keywordUnion: WithIndex[Index, LeftKeyword] +: RestKeyword, handler: Value => Domain): Domain = {
-      keywordUnion match {
-        case WithIndex(valueOfIndex.value, leftKeyword) =>
-          leftDsl.cpsApply(leftKeyword.asInstanceOf[LeftKeyword], handler)
-        case _ =>
-          restDsl.cpsApply(keywordUnion.asInstanceOf[RestKeyword], handler)
+    given [
+        Index <: Int,
+        LeftKeyword,
+        RestKeyword,
+        Domain,
+        Value
+    ](using
+        leftDsl: Dsl.IsKeyword[LeftKeyword, Value],
+        restDsl: Dsl.IsKeyword[RestKeyword, Value]
+    ): Dsl.IsKeyword[WithIndex[Index, LeftKeyword] +: RestKeyword, Value] with {}
+    given [
+        Index <: Int,
+        LeftKeyword,
+        RestKeyword,
+        Domain,
+        Value
+    ](using
+        leftDsl: Dsl.PolyCont[LeftKeyword, Domain, Value],
+        valueOfIndex: ValueOf[Index],
+        restDsl: Dsl.PolyCont[RestKeyword, Domain, Value]
+    ): Dsl.PolyCont[WithIndex[Index, LeftKeyword] +: RestKeyword, Domain, Value] with {
+      def cpsApply(keywordUnion: WithIndex[Index, LeftKeyword] +: RestKeyword, handler: Value => Domain): Domain = {
+        keywordUnion match {
+          case WithIndex(valueOfIndex.value, leftKeyword) =>
+            leftDsl.cpsApply(leftKeyword.asInstanceOf[LeftKeyword], handler)
+          case _ =>
+            restDsl.cpsApply(keywordUnion.asInstanceOf[RestKeyword], handler)
+        }
       }
     }
-  }
 
 }
 // @inline def Match = keywords.FlatMap

--- a/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
+++ b/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
@@ -7,7 +7,7 @@ object Match {
   export FlatMap.apply
   case class WithIndex[Index <: Int, +Keyword](index: Index, keyword: Keyword) extends Dsl.Keyword.Trait
 
-  opaque type +:[A, B] = A | B
+  opaque type +:[+A, +B] = A | B
 
   given [
       Index <: Int,

--- a/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
+++ b/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
@@ -2,10 +2,10 @@ package com.thoughtworks.dsl
 package keywords
 import Dsl.IsKeyword
 
-type Match[Keyword, Value, CaseSet] = keywords.FlatMap[Keyword, Value, CaseSet]
+type Match[+Keyword, Value, +CaseSet] = keywords.FlatMap[Keyword, Value, CaseSet]
 object Match {
   export FlatMap.apply
-  case class WithIndex[Index <: Int, Keyword](index: Index, keyword: Keyword) extends Dsl.Keyword.Trait
+  case class WithIndex[Index <: Int, +Keyword](index: Index, keyword: Keyword) extends Dsl.Keyword.Trait
 
   opaque type +:[A, B] = A | B
 

--- a/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
+++ b/keywords-Match/src/main/scala/com/thoughtworks/dsl/keywords/Match.scala
@@ -2,7 +2,7 @@ package com.thoughtworks.dsl
 package keywords
 import Dsl.IsKeyword
 
-type Match[+Keyword, Value, +CaseSet] = keywords.FlatMap[Keyword, Value, CaseSet]
+type Match[+Keyword, +CaseSet] = keywords.FlatMap[Keyword, CaseSet]
 object Match {
   export FlatMap.apply
   case class WithIndex[Index <: Int, +Keyword](index: Index, keyword: Keyword) extends Dsl.Keyword.Trait

--- a/keywords-Monadic/src/main/scala/com/thoughtworks/dsl/keywords/Monadic.scala
+++ b/keywords-Monadic/src/main/scala/com/thoughtworks/dsl/keywords/Monadic.scala
@@ -13,8 +13,8 @@ import scala.language.implicitConversions
   * @todo
   *   [[Monadic]] should be a [[scala.AnyVal]] after [[https://github.com/scala/bug/issues/10595]] is resolved.
   */
-opaque type Monadic[Functor[_], Value] <: Dsl.Keyword.Opaque =
-  Dsl.Keyword.Opaque.Of[Functor[Value]]
+opaque type Monadic[+FA] <: Dsl.Keyword.Opaque =
+  Dsl.Keyword.Opaque.Of[FA]
 
 object Monadic {
 
@@ -25,9 +25,9 @@ object Monadic {
       inline asFA: FA <:< F[A]
   )
     transparent inline def unary_! : A =
-      Dsl.shift[Monadic[F, A], A](Monadic[F, A](asFA(fa))): A
+      Dsl.shift[Monadic[FA], A](Monadic[FA](fa)): A
 
-  @inline def apply[Functor[_], Value]: Functor[Value] =:= Monadic[Functor, Value] = Dsl.Keyword.Opaque.Of.apply
+  @inline def apply[FA]: FA =:= Monadic[FA] = Dsl.Keyword.Opaque.Of.apply
 
-  given [Functor[_], Value]: IsKeyword[Monadic[Functor, Value], Value] with {}
+  given [FA <: F[A], F[_], A]: IsKeyword[Monadic[FA], A] with {}
 }

--- a/keywords-NoneSafe/src/main/scala/com/thoughtworks/dsl/keywords/NoneSafe.scala
+++ b/keywords-NoneSafe/src/main/scala/com/thoughtworks/dsl/keywords/NoneSafe.scala
@@ -3,7 +3,7 @@ package keywords
 import com.thoughtworks.dsl.Dsl.IsKeyword
 import scala.language.implicitConversions
 
-opaque type NoneSafe[A] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Option[A]]
+opaque type NoneSafe[+A] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Option[A]]
 
 object NoneSafe {
   given [A]: IsKeyword[NoneSafe[A], A] with {}

--- a/keywords-Put/src/main/scala/com/thoughtworks/dsl/keywords/Put.scala
+++ b/keywords-Put/src/main/scala/com/thoughtworks/dsl/keywords/Put.scala
@@ -61,7 +61,7 @@ import com.thoughtworks.dsl.Dsl.IsKeyword
   * @author
   *   杨博 (Yang Bo)
   */
-opaque type Put[S] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[S]
+opaque type Put[+S] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[S]
 
 object Put {
   given [S]: IsKeyword[Put[S], Unit] with {}

--- a/keywords-Return/src/main/scala/com/thoughtworks/dsl/keywords/Return.scala
+++ b/keywords-Return/src/main/scala/com/thoughtworks/dsl/keywords/Return.scala
@@ -13,7 +13,7 @@ import Dsl.Lift
   * @author
   *   杨博 (Yang Bo)
   */
-opaque type Return[ReturnValue] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[ReturnValue]
+opaque type Return[+ReturnValue] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[ReturnValue]
 object Return {
   @inline def apply[ReturnValue]: ReturnValue =:= Return[ReturnValue] = Dsl.Keyword.Opaque.Of.apply
 

--- a/keywords-Suspend/src/main/scala/com/thoughtworks/dsl/keywords/Suspend.scala
+++ b/keywords-Suspend/src/main/scala/com/thoughtworks/dsl/keywords/Suspend.scala
@@ -3,7 +3,7 @@ package keywords
 import Dsl.IsKeyword
 import Dsl.cpsApply
 
-opaque type Suspend[Keyword] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[() => Keyword]
+opaque type Suspend[+Keyword] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[() => Keyword]
 object Suspend {
   @inline def apply[Keyword]: (() => Keyword) =:= Suspend[Keyword] = Dsl.Keyword.Opaque.Of.apply
 

--- a/keywords-TryCatch/src/main/scala/com/thoughtworks/dsl/keywords/TryCatch.scala
+++ b/keywords-TryCatch/src/main/scala/com/thoughtworks/dsl/keywords/TryCatch.scala
@@ -7,7 +7,7 @@ import scala.util.control.Exception.Catcher
 import scala.concurrent._
 import scala.util.control.NonFatal
 
-case class TryCatch[BlockKeyword, CaseKeyword](block: BlockKeyword, cases: Catcher[CaseKeyword]) extends Dsl.Keyword.Trait
+case class TryCatch[+BlockKeyword, +CaseKeyword](block: BlockKeyword, cases: Catcher[CaseKeyword]) extends Dsl.Keyword.Trait
 object TryCatch {
 
   given [Value, OuterDomain, BlockKeyword, BlockDomain, CaseKeyword](

--- a/keywords-TryCatchFinally/src/main/scala/com/thoughtworks/dsl/keywords/TryCatchFinally.scala
+++ b/keywords-TryCatchFinally/src/main/scala/com/thoughtworks/dsl/keywords/TryCatchFinally.scala
@@ -4,7 +4,7 @@ import Dsl.!!
 import Dsl.IsKeyword
 import scala.util.control.Exception.Catcher
 
-case class TryCatchFinally[BlockKeyword, CaseKeyword, FinalizerKeyword](
+case class TryCatchFinally[+BlockKeyword, +CaseKeyword, +FinalizerKeyword](
     block: BlockKeyword,
     cases: Catcher[CaseKeyword],
     finalizer: FinalizerKeyword

--- a/keywords-TryFinally/src/main/scala/com/thoughtworks/dsl/keywords/TryFinally.scala
+++ b/keywords-TryFinally/src/main/scala/com/thoughtworks/dsl/keywords/TryFinally.scala
@@ -7,7 +7,7 @@ import scala.util.control.Exception.Catcher
 import scala.concurrent._
 import scala.util.control.NonFatal
 
-case class TryFinally[TryKeyword, FinalizerKeyword](
+case class TryFinally[+TryKeyword, +FinalizerKeyword](
     block: TryKeyword,
     finalizer: FinalizerKeyword
 ) extends Dsl.Keyword.Trait

--- a/keywords-Typed/src/main/scala/com/thoughtworks/dsl/keywords/Typed.scala
+++ b/keywords-Typed/src/main/scala/com/thoughtworks/dsl/keywords/Typed.scala
@@ -2,7 +2,7 @@ package com.thoughtworks.dsl
 package keywords
 
 /** A type annotated keyword */
-opaque type Typed[Keyword, Value] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Keyword]
+opaque type Typed[+Keyword, +Value] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Keyword]
 
 object Typed {
   given [Keyword, Value]

--- a/keywords-Using/src/main/scala/com/thoughtworks/dsl/keywords/Using.scala
+++ b/keywords-Using/src/main/scala/com/thoughtworks/dsl/keywords/Using.scala
@@ -21,7 +21,7 @@ import scala.util.control.NonFatal
   * @see
   *   [[dsl]] for usage of this [[Using]] keyword in continuations
   */
-opaque type Using[R] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[R]
+opaque type Using[+R] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[R]
 
 object Using {
   given [R]: IsKeyword[Using[R], R] with {}

--- a/keywords-Using/src/main/scala/com/thoughtworks/dsl/keywords/Using.scala
+++ b/keywords-Using/src/main/scala/com/thoughtworks/dsl/keywords/Using.scala
@@ -87,8 +87,8 @@ object Using {
       IsKeyword[Mapped, MappedValue],
       Dsl.TryFinally[MappedValue, OuterDomain, BlockDomain, FinalizerDomain],
       Dsl.PolyCont[Mapped, BlockDomain, MappedValue]
-  ): Dsl.PolyCont[FlatMap[Using[R], R, Mapped], OuterDomain, MappedValue] = {
-    case (FlatMap(r, flatMapper), handler) =>
+  ): Dsl.PolyCont[FlatMap[Using[R], Mapped], OuterDomain, MappedValue] = {
+    case (FlatMap(r, flatMapper: (Using[R] @unchecked => Mapped)), handler) =>
       reset {
         handler(try {
           !flatMapper(r)

--- a/keywords-While/src/main/scala/com/thoughtworks/dsl/keywords/While.scala
+++ b/keywords-While/src/main/scala/com/thoughtworks/dsl/keywords/While.scala
@@ -4,8 +4,8 @@ import Dsl.IsKeyword
 import Dsl.cpsApply
 
 case class While[
-    ConditionKeyword,
-    BodyKeyword
+    +ConditionKeyword,
+    +BodyKeyword
 ](
     condition: ConditionKeyword,
     body: BodyKeyword

--- a/keywords-Yield/src/main/scala/com/thoughtworks/dsl/keywords/Yield.scala
+++ b/keywords-Yield/src/main/scala/com/thoughtworks/dsl/keywords/Yield.scala
@@ -39,7 +39,7 @@ import scala.language.higherKinds
   *          }}}
   * @see [[comprehension]] if you want to use traditional `for` comprehension instead of !-notation.
   */
-opaque type Yield[Element] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Element]
+opaque type Yield[+Element] <: Dsl.Keyword.Opaque = Dsl.Keyword.Opaque.Of[Element]
 
 private[keywords] trait LowPriorityYield3 {
 

--- a/reset/src/main/scala/com/thoughtworks/dsl/reset.scala
+++ b/reset/src/main/scala/com/thoughtworks/dsl/reset.scala
@@ -629,7 +629,6 @@ object reset {
               val flatMapObject = '{keywords.FlatMap}.asTerm
               Apply(TypeApply(Select.unique(flatMapObject, "apply"), List(
                 TypeTree.of[K],
-                TypeTree.of[V],
                 TypeTree.of[X],
               )), List(keywordExpr.asTerm, flatMapperTerm)) -> innerKeywordTree.valueType
             }

--- a/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
+++ b/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
@@ -85,8 +85,7 @@ object ReturnSpec extends TestSuite {
             com.thoughtworks.dsl.keywords.Pure$package.Pure[scala.Boolean],
             com.thoughtworks.dsl.keywords.Suspend$package.Suspend[com.thoughtworks.dsl.keywords.Pure$package.Pure[scala.Double]],
             com.thoughtworks.dsl.keywords.Suspend$package.Suspend[com.thoughtworks.dsl.keywords.Pure$package.Pure[scala.Double]]
-          ], scala.Double, com.thoughtworks.dsl.keywords.Pure$package.Pure[scala.Double]], Double !! Double, Double ]]
-        
+          ], com.thoughtworks.dsl.keywords.Pure$package.Pure[scala.Double]], Double !! Double, Double ]]
       }
       "condition" - {
         val continuation = *[[X] =>> AnyRef !! X] {

--- a/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
+++ b/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
@@ -89,10 +89,10 @@ object ReturnSpec extends TestSuite {
         
       }
       "condition" - {
-        val continuation = *[[X] =>> Double !! X] {
+        val continuation = *[[X] =>> AnyRef !! X] {
           val b = true
-          val c = 3.14
-          val d = 6.28
+          val c = "my string"
+          val d = new StringBuilder
           if (b) {
             c
           } else {
@@ -100,7 +100,7 @@ object ReturnSpec extends TestSuite {
           }
         }
 
-        assert(continuation(identity) == 3.14)
+        assert(continuation(identity) == "my string")
       }
     }
 

--- a/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
+++ b/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
@@ -91,10 +91,12 @@ object ReturnSpec extends TestSuite {
       "condition" - {
         val continuation = *[[X] =>> Double !! X] {
           val b = true
+          val c = 3.14
+          val d = 6.28
           if (b) {
-            3.14
+            c
           } else {
-            6.28
+            d
           }
         }
 

--- a/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
+++ b/reset/src/test/scala/com/thoughtworks/dsl/keywords/ReturnSpec.scala
@@ -6,6 +6,7 @@ import utest.{TestSuite, Tests, given}
 import Dsl.Run
 import scala.language.implicitConversions
 import Dsl.IsKeyword
+import scala.util.control.NonFatal
 
 /**
   * @author 杨博 (Yang Bo)
@@ -100,6 +101,35 @@ object ReturnSpec extends TestSuite {
         }
 
         assert(continuation(identity) == "my string")
+      }
+      "match / case " - {
+        val continuation = *[[X] =>> AnyRef !! X] {
+          val b = true
+          val c = "my string"
+          val d = new StringBuilder
+          b match {
+            case true =>
+              "my string"
+            case false =>
+              d
+          }
+        }
+
+        assert(continuation(identity) == "my string")
+      }
+
+      "try / catch" - {
+        val continuation = *[[X] =>> Unit !! Throwable !! X] {
+          val c = "my string"
+          val d = new StringBuilder
+          try {
+            c
+          } catch {
+            case NonFatal(e) =>
+              d
+          }
+        }
+
       }
     }
 


### PR DESCRIPTION
The Scala 3 compiler will not be able to infer the whole type tree if any leaf symbol is local, see
https://github.com/lampepfl/dotty/issues/14152

As a workaround, we should let the type tree be as covariant as possible to minimized type information loss